### PR TITLE
Fix role change

### DIFF
--- a/src/components/buttons/roleChange.ts
+++ b/src/components/buttons/roleChange.ts
@@ -1,5 +1,6 @@
 import { ButtonBuilder, ButtonStyle, Role } from "discord.js";
 import { Button } from "../../structures/Button";
+import { isEditable } from "../../utils/isEditable";
 import { reply } from "../../utils/Reply";
 
 export default new Button({
@@ -16,6 +17,7 @@ export default new Button({
         const after = await interaction.guild?.roles.fetch(afterId);
 
         if (!before || !after) return reply(interaction, "ロールが見つかりません");
+        if (!isEditable(before) || !isEditable(after)) return reply(interaction, "マダミナリンクより上位のロールは編集できません");
         await interaction.deferReply({ ephemeral: true });
 
         await interaction.guild?.members.fetch();

--- a/src/components/buttons/roleChange.ts
+++ b/src/components/buttons/roleChange.ts
@@ -26,10 +26,7 @@ export default new Button({
         if (members.size === 0) return reply(interaction, `${before}を持つメンバーがいません`);
 
         await Promise.all(
-            members.map(async member => {
-                member.roles.remove(before);
-                member.roles.add(after);
-            })
+            members.map(async member => member.roles.set(member.roles.cache.set(after.id, after).filter(role => role.id !== before.id)))
         );
 
         await reply(interaction, `${[...members.values()].join(", ")}の${before}を${after}に変更しました`);

--- a/src/components/buttons/roleChange.ts
+++ b/src/components/buttons/roleChange.ts
@@ -26,9 +26,10 @@ export default new Button({
         if (members.size === 0) return reply(interaction, `${before}を持つメンバーがいません`);
 
         await Promise.all(
-            members.map(async member =>
-                member.roles.set([after, ...member.roles.cache.values()].filter(role => role.id !== before.id))
-            )
+            members.map(async member => {
+                member.roles.remove(before);
+                member.roles.add(after);
+            })
         );
 
         await reply(interaction, `${[...members.values()].join(", ")}の${before}を${after}に変更しました`);


### PR DESCRIPTION
/role changeに関するバグを2つ修正
* 変更後のロールをすでに持っている場合に落ちる（単に変更前のロールを削除するように）
* 自分より上位のロールを編集しようとした場合にサイレントで落ちている
 →その後ちゃんと本家のマダミナリンクで確認したら落ちてないんですが、まあ入れちゃったので残しておきます

より良い実装方法や、そもそも変更後ロール所持時の挙動の解釈違いなどあれば教えてください。