### PR TITLE
これ以前・以降を削除がシステムメッセージを消そうとするのを修正

### DIFF
--- a/src/utils/DeleteMultiMessages.ts
+++ b/src/utils/DeleteMultiMessages.ts
@@ -5,15 +5,16 @@ export const deleteMultiMessages = async (
     channel: GuildTextBasedChannel | DMChannel | PartialDMChannel,
     messages: Collection<string, Message<boolean>>
 ) => {
-    const threads = messages.filter(m => m.hasThread).map(m => m.thread as AnyThreadChannel);
-    const [recentMessages, oldMessages] = messages.partition(
+    const nonSystemMessages = messages.filter(message => !message.system);
+    const threads = nonSystemMessages.filter(m => m.hasThread).map(m => m.thread as AnyThreadChannel);
+    const [recentMessages, oldMessages] = nonSystemMessages.partition(
         message => Date.now() - message.createdTimestamp < 1_209_600_000
     );
 
     if (!("bulkDelete" in channel)) {
         //bulkDeleteがない場合は一つずつ削除
         await Promise.all(
-            messages.map(async message => {
+            nonSystemMessages.map(async message => {
                 await message.delete();
             })
         );


### PR DESCRIPTION
タイトル通り。

下記が怪しいが、draftかと言うとそうでもないのでとりあえず普通にプルリク
1. 全部システムメッセージで消すものがなかった時でも、完了メッセージが「メッセージを削除しました」になっている
1. デグレ確認などの動作確認