### PR TITLE
コードを整理

### DIFF
--- a/src/utils/DeleteMultiMessages.ts
+++ b/src/utils/DeleteMultiMessages.ts
@@ -6,29 +6,24 @@ export const deleteMultiMessages = async (
     messages: Collection<string, Message<boolean>>
 ) => {
     const nonSystemMessages = messages.filter(message => !message.system);
-    const threads = nonSystemMessages.filter(m => m.hasThread).map(m => m.thread as AnyThreadChannel);
-    const [recentMessages, oldMessages] = nonSystemMessages.partition(
-        message => Date.now() - message.createdTimestamp < 1_209_600_000
-    );
 
     if (!("bulkDelete" in channel)) {
         //bulkDeleteがない場合は一つずつ削除
-        await Promise.all(
-            nonSystemMessages.map(async message => {
-                await message.delete();
-            })
-        );
+        await Promise.all(nonSystemMessages.map(message => message.delete()));
         return;
     }
 
+    const [recentMessages, oldMessages] = nonSystemMessages.partition(message => message.bulkDeletable);
+
     //bulkDeleteで100件ずつ削除
     await Promise.all(
-        arraySplit([...recentMessages.values()], 100).map(async messagesSliced => channel.bulkDelete(messagesSliced))
+        arraySplit([...recentMessages.values()], 100).map(messagesSliced => channel.bulkDelete(messagesSliced))
     );
 
     //２週間以上前のメッセージを順番に削除(遅い)
-    await Promise.all(oldMessages.map(async message => message.delete()));
+    await Promise.all(oldMessages.map(message => message.delete()));
 
     //メッセージに付属するスレッドも削除
-    await Promise.all(threads.map(async thread => thread.delete()));
+    const threads = nonSystemMessages.map(m => m.thread).filter((t): t is AnyThreadChannel => !!t);
+    await Promise.all(threads.map(thread => thread.delete()));
 };


### PR DESCRIPTION
コメントに書いた分のリファクタリングを実装＆動作確認まで済
関数の仕様として削除したメッセージのCollectionを返すという仕様にしたいという話が上がってましたが上手く実装できませんでした
bulkDeleteの戻り値を見たんですがUndefinedになっていたので単純に自分が仕様を勘違いしてた説があります
削除したメッセージがない場合の条件分岐は一旦諦めてシステムメッセージのフィルターだけでもmasterに取り込みたいです
動作確認だけしてもらって問題なければfix-delete-contexにマージしちゃってください
その後こちらでmasterにマージして本番環境に投げときます