### PR TITLE
列数の上限に対応

### DIFF
--- a/src/commands/slashcommands/transfer.ts
+++ b/src/commands/slashcommands/transfer.ts
@@ -19,6 +19,7 @@ import transferButton from "../../components/buttons/transfer";
 import transferList from "../../components/selectmenu/transferList";
 import { reply } from "../../utils/Reply";
 import { buttonToRow } from "../../utils/ButtonToRow";
+import { arraySplit } from "../../utils/ArraySplit";
 
 const OPTION_NAME_DESTINATION = "転送先";
 
@@ -53,11 +54,24 @@ export default new SlashCommand({
         )?.filter((channel): channel is TextChannel | NewsChannel | VoiceChannel => channel.isTextBased());
 
         if (!channels) return;
+        const components = transferList.build([...discordSort(channels).values()]);
 
-        await reply(interaction, {
-            content: "転送先のチャンネルを選択してください",
-            components: transferList.build([...discordSort(channels).values()]),
-        });
+        if (components.length <= 5) {
+            return reply(interaction, {
+                content: "転送先のチャンネルを選択してください",
+                components,
+            });
+        } else {
+            const splitedComponents = arraySplit(components, 5);
+            await reply(interaction, {
+                content: "転送先のチャンネルを選択してください",
+                components: splitedComponents[0],
+            });
+            await Promise.all(
+                splitedComponents.slice(1).map(async component => reply(interaction, { components: component }))
+            );
+        }
+
     },
 });
 


### PR DESCRIPTION
#36 
カテゴリーに入ってないチャンネルが選択肢として表示される機能自体は昔の自分が実装してました (えらい)
ただActionRowの列数が5列を超えてエラーになってました
一つのActionRowに選択肢を25個まで入れられるのでチャンネル数が125を超えたらメッセージを二つに分けるように変更してます
マダミスのサーバーとしてここまでカテゴリー分けされてないものも珍しいので報告が上がらなかったと思われます
個人的にはこれだけ選択肢が多いと押し間違いのリスクしかないと思っているので不要な機能の気もしますがそれでもエラーが表示されるよりはマシかなと思って一応実装しました
![image](https://github.com/minarin0179/Madaminalink_v2/assets/55317109/180b620e-1add-4afd-bcb7-43555a0311bf)
