### PR TITLE
fix:SendMessagesの権限を明示的に指定

### DIFF
--- a/src/commands/slashcommands/setup.ts
+++ b/src/commands/slashcommands/setup.ts
@@ -70,6 +70,7 @@ export default new SlashCommand({
             //見れない
             deny: [
                 PermissionFlagsBits.ViewChannel,
+                PermissionFlagsBits.SendMessages,
                 PermissionFlagsBits.CreatePublicThreads,
                 PermissionFlagsBits.CreatePrivateThreads,
                 PermissionFlagsBits.SendMessagesInThreads,
@@ -86,7 +87,9 @@ export default new SlashCommand({
                 PermissionFlagsBits.SendMessagesInThreads,
             ],
         };
-        const writable = { allow: [PermissionFlagsBits.ViewChannel, PermissionFlagsBits.Connect] }; //書き込める
+        const writable = {
+            allow: [PermissionFlagsBits.ViewChannel, PermissionFlagsBits.SendMessages, PermissionFlagsBits.Connect],
+        }; //書き込める
 
         const defaultPerm = [
             { id: everyone.id, ...invisible },


### PR DESCRIPTION
invisibleにSendMessagesがdenyで設定されていなかったのは単純にミスっぽい
writableにSendMessagesをallowで指定するのはほぼ関係がないけどロール全体の権限を書き込み不可とかに設定されてても書き込めるようになる
なるべくロール自体の権限の影響を受けたくないので明示的に追加しておくのがよさそう