### PR TITLE
Fix: /pollに各種数量制限を追加

### DIFF
--- a/src/commands/slashcommands/archive.ts
+++ b/src/commands/slashcommands/archive.ts
@@ -100,7 +100,9 @@ export default new SlashCommand({
         for await (const descriptions of descriptionsConcat) {
             await logChannel.send({
                 embeds: descriptions.map((description, index) => {
-                    const embedBuilder = new EmbedBuilder().setColor([47, 49, 54]).setDescription(description);
+                    const embedBuilder = new EmbedBuilder()
+                        .setColor(MyConstants.color.embed_background)
+                        .setDescription(description);
                     if (index == 0) {
                         embedBuilder.setTitle(targetCategory.name);
                     }
@@ -218,7 +220,9 @@ const messageToArchiveDatas = (message: Message): ArchiveData[] => {
     const authorName = message.member?.nickname || message.author.globalName || message.author.username;
     const splittedDescription = splitMessage(description, { maxLength: 3000 });
     const datas: ArchiveData[] = splittedDescription.map((description, index) => {
-        const messageEmbed = new EmbedBuilder().setDescription(description).setColor([47, 49, 54]);
+        const messageEmbed = new EmbedBuilder()
+            .setDescription(description)
+            .setColor(MyConstants.color.embed_background);
         const data: ArchiveData = {
             embed: messageEmbed,
             files: [],

--- a/src/commands/slashcommands/poll.ts
+++ b/src/commands/slashcommands/poll.ts
@@ -1,4 +1,4 @@
-import { ButtonInteraction, CommandInteraction, ComponentType, SlashCommandBuilder } from "discord.js";
+import { ButtonInteraction, CommandInteraction, ComponentType, MessageFlags, SlashCommandBuilder } from "discord.js";
 import { SlashCommand } from "../../structures/SlashCommand";
 import { reply } from "../../utils/Reply";
 import pollButton from "../../components/buttons/poll";
@@ -6,6 +6,7 @@ import { buttonToRow } from "../../utils/ButtonToRow";
 import confirmPollButton from "../../components/buttons/confirmPoll";
 import { Choice, PollModel, PollOptions } from "../../structures/Poll";
 import agregatePollButton from "../../components/buttons/agregatePoll";
+import { MyConstants } from "../../constants/constants";
 
 export default new SlashCommand({
     data: new SlashCommandBuilder()
@@ -39,8 +40,12 @@ export default new SlashCommand({
                 } as Choice;
             });
 
-        if (choices.length > 24)
-            return reply(interaction, { content: "選択肢の数が多すぎます(最大24個)", ephemeral: true });
+        if (choices.length > MyConstants.maxPollChoices) {
+            return reply(interaction, `選択肢の数が多すぎます(最大${MyConstants.maxPollChoices}個)`);
+        }
+        if (choices.some(choice => !!choice.roleId && choice.label.length > MyConstants.maxPollchoiceLength)) {
+            return reply(interaction, `選択肢の文字数が多すぎます(最大${MyConstants.maxPollchoiceLength}文字)`);
+        }
 
         const pollOptions = {
             type: voteType,

--- a/src/commands/slashcommands/rename.ts
+++ b/src/commands/slashcommands/rename.ts
@@ -1,6 +1,7 @@
 import { GuildMember, Role, SlashCommandBuilder } from "discord.js";
 import { SlashCommand } from "../../structures/SlashCommand";
 import { reply } from "../../utils/Reply";
+import { MyConstants } from "../../constants/constants";
 
 export default new SlashCommand({
     data: new SlashCommandBuilder()
@@ -53,7 +54,10 @@ export default new SlashCommand({
 export const rename = async (member: GuildMember, prefix?: string | null) => {
     const nickname = member.nickname?.replace("＠", "@");
     //@より後ろの名前
-    const name = nickname?.substring(nickname.lastIndexOf("@") + 1) || member.user.globalName;
-
-    return member.setNickname(!prefix ? name : `${prefix}@${name}`);
+    const name = nickname?.substring(nickname.lastIndexOf("@") + 1) || member.user.globalName || member.user.username;
+    let newName = !prefix ? name : `${prefix}@${name}`;
+    if (newName.length > MyConstants.maxNicknameLength) {
+        newName = newName.substring(0, MyConstants.maxNicknameLength);
+    }
+    return member.setNickname(newName);
 };

--- a/src/components/buttons/agregatePoll.ts
+++ b/src/components/buttons/agregatePoll.ts
@@ -1,4 +1,4 @@
-import { ButtonBuilder, ButtonStyle, Collection, EmbedBuilder, GuildMember, Role } from "discord.js";
+import { ButtonBuilder, ButtonStyle, Collection, Colors, EmbedBuilder, GuildMember, Role } from "discord.js";
 import { Button } from "../../structures/Button";
 import { PollModel } from "../../structures/Poll";
 import { reply } from "../../utils/Reply";
@@ -7,6 +7,7 @@ import revoteButton from "./revote";
 import { buttonToRow } from "../../utils/ButtonToRow";
 import { rename } from "../../commands/slashcommands/rename";
 import runoffVoteButton from "./runoffVote";
+import { splitMessage } from "../../utils/SplitMessage";
 
 export default new Button({
     customId: "agregatePoll",
@@ -59,12 +60,12 @@ export default new Button({
                 }
             }
 
+            const descrption = `### 集計結果\n${content || "なし"}`;
+
             await interaction.channel?.send({
-                embeds: [
-                    new EmbedBuilder()
-                        .addFields({ name: "集計結果", value: content || "なし" })
-                        .setColor(warn ? 0xffcc4d : 0x77b255),
-                ],
+                embeds: splitMessage(descrption).map(text =>
+                    new EmbedBuilder().setDescription(text).setColor(warn ? Colors.Yellow : Colors.Green)
+                ),
                 allowedMentions: { parse: [] },
                 components: warn ? buttonToRow(revoteButton.build({ pollId })) : [],
             });
@@ -85,7 +86,6 @@ export default new Button({
                     });
                 }
             }
-
         } else if (poll.type === "vote") {
             result.sort((a, b) => b.length - a.length);
 
@@ -104,15 +104,11 @@ export default new Button({
                 .join("\n");
             const topVoteGetters = result.filter(voters => voters.length === result.first()?.length);
 
+            const descrption = `### 投票数\n${numOfVotes || "なし"}\n### 投票先\n${votings || "なし"}`;
             await reply(interaction, {
-                embeds: [
-                    new EmbedBuilder()
-                        .addFields(
-                            { name: "投票数", value: numOfVotes || "なし" },
-                            { name: "投票先", value: votings || "なし" }
-                        )
-                        .setColor(0x3b88c3),
-                ],
+                embeds: splitMessage(descrption).map(text =>
+                    new EmbedBuilder().setDescription(text).setColor(Colors.Blue)
+                ),
                 allowedMentions: { parse: [] },
                 components: buttonToRow([
                     ...unehemeralButton.build(),

--- a/src/components/buttons/confirmPoll.ts
+++ b/src/components/buttons/confirmPoll.ts
@@ -2,6 +2,7 @@ import { ButtonBuilder, ButtonStyle, EmbedBuilder } from "discord.js";
 import { Button } from "../../structures/Button";
 import { PollModel } from "../../structures/Poll";
 import { reply } from "../../utils/Reply";
+import { MyConstants } from "../../constants/constants";
 
 export default new Button({
     customId: "confirmPoll",
@@ -32,7 +33,7 @@ export default new Button({
                 new EmbedBuilder()
                     .addFields({ name: "投票数", value: poll.voters.size.toString() })
                     .addFields({ name: "投票状況", value: content || "まだ投票がありません" })
-                    .setColor(0x2f3136),
+                    .setColor(MyConstants.color.embed_background),
             ],
         });
     },

--- a/src/components/buttons/poll.ts
+++ b/src/components/buttons/poll.ts
@@ -3,10 +3,11 @@ import { Button } from "../../structures/Button";
 import { LimitLength } from "../../utils/LimitLength";
 import { Choice, PollModel } from "../../structures/Poll";
 import { reply } from "../../utils/Reply";
+import { MyConstants } from "../../constants/constants";
 
 export default new Button({
     customId: "poll",
-    build: ({ pollId, choices }: { pollId: string, choices: Choice[]; }) =>
+    build: ({ pollId, choices }: { pollId: string; choices: Choice[] }) =>
         choices.map((choice, index) => {
             const label = LimitLength(choice.label, 16);
 
@@ -22,6 +23,20 @@ export default new Button({
         if (!poll) return;
 
         const isVoted = poll.voters.has(interaction.user.id);
+
+        if (!isVoted) {
+            if (poll.type === "char" && poll.voters.size >= MyConstants.maxCharVoters) {
+                return reply(interaction, {
+                    content: `投票へ参加できる人数が上限に達しています(キャラ選択に参加できるのは最大で${MyConstants.maxCharVoters}人です)`,
+                    ephemeral: false,
+                });
+            } else if (poll.type === "vote" && poll.voters.size >= MyConstants.maxVoteVoters) {
+                return reply(interaction, {
+                    content: `投票へ参加できる人数が上限に達しています(犯人投票に参加できるのは最大で${MyConstants.maxVoteVoters}人です)`,
+                    ephemeral: false,
+                });
+            }
+        }
 
         poll.voters.set(interaction.user.id, choiceId);
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -2,4 +2,12 @@ export namespace MyConstants {
     export const mebi = 1 << 20;
     export const maxFileSizeMB = 25;
     export const maxFileSize = maxFileSizeMB * mebi;
+    export const color = {
+        embed_background: 0x2c2d31,
+    }
+    export const maxPollChoices = 23; //pollの選択肢の最大数
+    export const maxPollchoiceLength = 50; //pollでの選択肢の最大文字数
+    export const maxCharVoters = 50; //キャラ選択の最大投票数
+    export const maxVoteVoters = 25; //犯人投票の最大投票数
+    export const maxNicknameLength = 32; //ニックネームの最大文字数
 }


### PR DESCRIPTION
以下を実装
- pollの結果表示をfieldからdescriptionに変更
- 選択肢の文字数を50文字までに制限
- 投票に参加できる人数を制限
  - キャラ投票は50人まで
  - 犯人投票は25人まで
- 選択肢の上限を修正 24⇒23
- ニックネームを変更する際に文字数を超えたら超えた分は削除
- リファクタリング
 - embedの色指定を定数で統一(これにより一部embedの色が変更) 
