### PR TITLE
fix: /setupの書き込み権限を最小化

### DIFF
--- a/src/commands/slashcommands/setup.ts
+++ b/src/commands/slashcommands/setup.ts
@@ -68,14 +68,7 @@ export default new SlashCommand({
 
         const invisible = {
             //見れない
-            deny: [
-                PermissionFlagsBits.ViewChannel,
-                PermissionFlagsBits.SendMessages,
-                PermissionFlagsBits.CreatePublicThreads,
-                PermissionFlagsBits.CreatePrivateThreads,
-                PermissionFlagsBits.SendMessagesInThreads,
-                PermissionFlagsBits.Connect,
-            ],
+            deny: [PermissionFlagsBits.ViewChannel, PermissionFlagsBits.Connect],
         };
         const visible = {
             // 見れるけど書き込めない


### PR DESCRIPTION
/setupで見えないチャンネルにおける権限設定を変更しました
これにより個別チャンネルをメンバーに権限付与した際に書き込み権限がない問題が解消されます